### PR TITLE
PT-3165: Rails 8 compatibility (backwards-compatible with 7.2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@
 
 Gemfile.lock
 /spec/dummy
+/vendor/bundle

--- a/Gemfile
+++ b/Gemfile
@@ -2,20 +2,39 @@ source "https://rubygems.org"
 
 git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'master')
-
-gem "solidus", github: "solidusio/solidus", branch: branch
+# Consume Printavo's Solidus fork (Solidus 2.11.16 + Rails 8 compat + state_machines
+# pin). Works on both the Rails 7.2 and Rails 8.0 axes.
+gem "solidus", git: "https://github.com/Printavo/solidus.git", branch: "rails-8.0-support"
 
 if ENV['RAILS_VERSION']
-  gem "rails", ENV['RAILS_VERSON']
+  # Was ENV['RAILS_VERSON'] (typo): the requested Rails version was silently
+  # dropped, so the dummy app always resolved against whatever railties the
+  # Solidus dependency pulled in rather than the axis under test.
+  gem "rails", ENV['RAILS_VERSION'], require: false
 end
 
-if ENV.fetch('DB') == 'postgres'
+# ENV.fetch('DB') with no default raises KeyError when DB is unset; the dummy app
+# defaults to sqlite, so default to sqlite and only pull pg when explicitly asked.
+if ENV.fetch('DB', nil) == 'postgres'
   gem 'pg'
+else
+  # The dummy app uses sqlite by default but the gem was never declared as a
+  # dependency, so the generated dummy could not connect.
+  gem 'sqlite3'
 end
 
 group :development, :test do
   gem "pry"
+
+  # Test-harness modernization for Rails 7.2/8.0 on Ruby 3.4.
+  # rspec-rails 8.x removed fixture_path=, which the Solidus 2.11 dummy relies on.
+  gem "rspec-rails", "~> 7.1"
+  gem "database_cleaner", "~> 2.0"
+  gem "sprockets", "~> 4"
+  # Ruby 3.4 extracted these from stdlib into bundled/default gems; pin them
+  # explicitly so they resolve when the dummy app and Rails reference them.
+  gem "mutex_m"
+  gem "benchmark"
 end
 
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,4 @@
+require "fileutils"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require 'spree/testing_support/extension_rake'
@@ -15,5 +16,35 @@ end
 desc 'Generates a dummy app for testing'
 task :test_app do
   ENV['LIB_NAME'] = 'super_good/solidus_taxjar'
-  Rake::Task['extension:test_app'].invoke
+
+  begin
+    Rake::Task['extension:test_app'].invoke
+  rescue => error
+    # Rails 8: Rails no longer generates a sprockets manifest, but Solidus still
+    # uses sprockets, so sprockets-rails 3.5 aborts boot with a
+    # Sprockets::Railtie::ManifestNeededError before the dummy app's database is
+    # ever set up. Upstream fixed this by having the generators write
+    # app/assets/config/manifest.js (mirrors solidusio/solidus#6121, #6122; see
+    # also #6327 / #3379). The Solidus 2.11 generators predate that, so seed the
+    # manifest here and re-run the database setup that common:test_app aborted.
+    # common:test_app shells out via `sh`, so the boot failure surfaces as a
+    # generic "Command failed" RuntimeError; recover only when the dummy app
+    # exists but is missing the manifest that triggers this exact abort.
+    manifest_path = File.expand_path("spec/dummy/app/assets/config/manifest.js", __dir__)
+    dummy_generated = File.exist?(File.expand_path("spec/dummy/config/environment.rb", __dir__))
+    raise unless dummy_generated && !File.exist?(manifest_path)
+
+    FileUtils.mkdir_p(File.dirname(manifest_path))
+    File.write(manifest_path, <<~MANIFEST)
+      //= link_tree ../images
+      //= link_directory ../javascripts .js
+      //= link_directory ../stylesheets .css
+    MANIFEST
+
+    Dir.chdir(File.expand_path("spec/dummy", __dir__)) do
+      sh "bin/rails railties:install:migrations RAILS_ENV=test"
+      sh "bin/rails db:environment:set RAILS_ENV=test"
+      sh "bin/rails db:drop db:create db:migrate VERBOSE=false RAILS_ENV=test"
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,13 @@ rescue LoadError
   exit
 end
 
+# The Solidus 2.11 generator + chained db:create/db:migrate populates the dummy
+# app's schema.rb but can leave the sqlite database file empty, so the spree_*
+# tables are missing at spec time. maintain_test_schema! loads schema.rb into the
+# database -- the standard rails_helper recovery for a stale/empty test schema.
+require "active_record"
+ActiveRecord::Migration.maintain_test_schema!
+
 RSpec.configure do |config|
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/super_good-solidus_taxjar.gemspec
+++ b/super_good-solidus_taxjar.gemspec
@@ -28,7 +28,10 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "database_cleaner"
-  spec.add_development_dependency "rake", "~> 10.0"
+  # Rails 7.2+ railties requires rake >= 12.2; the original "~> 10.0" pin is
+  # unsatisfiable. Must live in the gemspec (not the Gemfile) or bundler rejects
+  # the conflicting requirements.
+  spec.add_development_dependency "rake", ">= 12.2"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "vcr", "~> 4.0"


### PR DESCRIPTION
## What & why

Applies Printavo's Rails 8 upgrade pattern to `super_good-solidus_taxjar`, making the
extension's test suite boot and pass on **both** Rails 7.2 and Rails 8.0 while
consuming Printavo's Solidus fork (Solidus 2.11.16 + Rails 8 compat). The base of
this PR (`rails-7.2-support`) is the exact ref the app consumes
(`ff3709966b598fae93d31d86cda26f7182be6aed`); this branch adds the compatibility
work on top.

All changes are backwards-compatible with Rails 7.2 — the same commits produce an
identical, green-modulo-pre-existing-drift run on both axes.

## Change groups

### Dependency modernization (`Gemfile`, gemspec)
- Redirect `solidus` to `Printavo/solidus` `rails-8.0-support` (Solidus 2.11.16 +
  Rails 8 compat + `state_machines < 0.10` pin). Resolves identically on both axes:
  `state_machines 0.6.0` / `-activemodel 0.9.0` / `-activerecord 0.9.0`, railties
  `7.2.3` / `8.0.5`.
- Fix `ENV['RAILS_VERSON']` typo → `RAILS_VERSION` (the requested Rails version was
  silently dropped, so the axis under test was never actually honored).
- `ENV.fetch('DB', nil)` — a bare `ENV.fetch('DB')` raised `KeyError` whenever `DB`
  was unset.
- Declare `sqlite3` on the default (non-postgres) path — the dummy app defaults to
  sqlite but the gem was never declared, so the dummy could not connect.
- Add Ruby-3.4 / harness gems: `rspec-rails ~> 7.1` (8.x removed `fixture_path=`
  which the 2.11 dummy relies on), `database_cleaner ~> 2.0`, `sprockets ~> 4`,
  `mutex_m`, `benchmark` (extracted from stdlib on Ruby 3.4).
- gemspec: `rake "~> 10.0"` → `">= 12.2"`. Rails 7.2+ railties requires rake
  ≥ 12.2; the old pin is unsatisfiable. Must live in the gemspec or bundler rejects
  the conflicting requirements.

### Test-harness boot (`Rakefile`, `spec/spec_helper.rb`)
- **`Rakefile`**: On Rails 8, Rails no longer generates a sprockets manifest, but
  Solidus still uses sprockets, so sprockets-rails 3.5 aborts dummy-app boot with
  `Sprockets::Railtie::ManifestNeededError` *before* the database is set up. The
  Solidus 2.11 generators predate the upstream fix, so we seed
  `app/assets/config/manifest.js` into the generated dummy and re-run the database
  setup that `common:test_app` aborted. Mirrors solidusio/solidus#6121, #6122 (see
  also #6327 / #3379). No-op on Rails 7.2 (the manifest error never fires).
- **`spec/spec_helper.rb`**: Load the dummy schema via
  `ActiveRecord::Migration.maintain_test_schema!`. The 2.11 generator + chained
  `db:create`/`db:migrate` populates `schema.rb` but can leave the sqlite file
  empty, so the `spree_*` tables are missing at spec time. This is the standard
  rails_helper recovery for a stale/empty test schema.

## Verification

Fresh lock per axis; `RAILS_VERSION` passed on every command; `DB=sqlite`.

| Axis        | examples | failures | pending |
|-------------|----------|----------|---------|
| Rails 7.2.3 | 40       | 3        | 0       |
| Rails 8.0.5 | 40       | 3        | 0       |

37 pass on both axes. No live API calls — the `Taxjar::Client` is mocked throughout.

## Residual failures (pre-existing fork drift — classified, NOT fixed)

All 3 failures are **identical on both axes** (same examples, same error messages),
confirming they are pre-existing source/spec drift in the fork and unrelated to the
Rails version:

1. `api_spec.rb:13` — *"puts the API version in the header"*.
   `RSpec::Mocks` "Exactly one instance should have received `set_api_config`".
   The fork commit **ff37099 "Simplify header setup"** (the consumed HEAD) changed
   `api.rb` to pass the version via the `headers:` argument to `Taxjar::Client.new`
   instead of calling `set_api_config`, but the spec was never updated to match.
2. `api_params_spec.rb:125` and `:155` — `#order_params`.
   `NoMethodError: undefined method 'for_delivery?' for an instance of
   Spree::Order`. Fork commit **8ece8d7** made `order_params` call Printavo app
   decorators (`order.for_delivery?`, `order.store.account.merch_stock_location`)
   that don't exist on a plain dummy-app `Spree::Order`; the specs still assert the
   upstream SuperGood shape.

These are source-vs-spec mismatches baked into the fork before this work; fixing
them is out of scope for a Rails-compatibility PR.

## Self-appointed fixes

None. Every non-trivial change maps to upstream Solidus continuous development (cited
inline) or is a harness-only dependency adjustment with a rationale comment.


## Upstream references

- [SuperGoodSoft/solidus_taxjar](https://github.com/SuperGoodSoft/solidus_taxjar) — this extension's own upstream (`super_good-solidus_taxjar`); the residual spec failures trace to fork commits ff37099 and 8ece8d7 against this lineage.
- [solidusio/solidus](https://github.com/solidusio/solidus) — Solidus core; source of the Rails 8 install-generator manifest fix (#6121, #6122) and the related sprockets manifest issues (#6327, #3379).
